### PR TITLE
Use flakes for configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 NixOS configuration files personalized for my workflow.
 
-To get started, install NixOS, clone this repository and run the rebuild command.
+To get started, install NixOS, enable flakes, clone this repository and run the rebuild command.
 
 ```sh
 git clone --recursive https://github.com/lavafroth/dotfiles
 ```
 
 ```sh
-sudo nixos-rebuild switch -I nixos-config=configuration.nix
+sudo nixos-rebuild switch --flake .#cafe
 ```
 
 #### Optional: Installing Sponsorblock for mpv

--- a/README.md
+++ b/README.md
@@ -2,21 +2,25 @@
 
 NixOS configuration files personalized for my workflow.
 
-To get started, install NixOS, enable flakes, clone this repository and run the rebuild command.
+To get started, install NixOS, enable flakes, clone this repository.
 
 ```sh
 git clone --recursive https://github.com/lavafroth/dotfiles
+cd dotfiles
 ```
 
+Now run the following rebuild command:
+
 ```sh
-sudo nixos-rebuild switch --flake .#cafe
+nix develop
+cafe-rebuild switch
 ```
 
 #### Optional: Installing Sponsorblock for mpv
 
 A fresh install is unlikely to have Rust and thus, the sponsorblock
 library won't be installed. Since I won't be uploading the compiled shared
-object, you have to compile it yourself. After the first `nixos-rebuild`, run:
+object, you have to compile it yourself. After the first rebuild, run:
 
 ```sh
 pushd sources/mpv-sponsorblock
@@ -25,4 +29,4 @@ cp ./target/release/libmpv_sponsorblock.so ../mpv/scripts/sponsorblock.so
 popd
 ```
 
-followed by the aforementioned `nixos-rebuild` command.
+followed by another rebuild.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Now run the following rebuild command:
 
 ```sh
 nix develop
-cafe-rebuild switch
+sudo cafe-rebuild switch
 ```
 
 #### Optional: Installing Sponsorblock for mpv

--- a/configuration.nix
+++ b/configuration.nix
@@ -226,11 +226,7 @@
   };
 
   # Enable nix-command for search and flakes
-  nix = {
-   package = pkgs.nixFlakes;
-   extraOptions = pkgs.lib.optionalString (config.nix.package == pkgs.nixFlakes)
-     "experimental-features = nix-command flakes";
-  };
+  nix.settings.experimental-features = [ "nix-command" "flakes" ];
 
   system.autoUpgrade.enable = false;
 

--- a/configuration.nix
+++ b/configuration.nix
@@ -5,7 +5,7 @@
 {
   imports =
     [ # Include the results of the hardware scan.
-      ./home.nix
+      # ./home.nix
       ./hardware-configuration.nix
       ./gnome-extensions.nix
     ];
@@ -177,7 +177,6 @@
       gh
       ghidra
       gimp
-      git
       gnome.gnome-boxes
       gnome.gnome-tweaks
       gnome-secrets
@@ -280,6 +279,7 @@
     aircrack-ng
     bat
     exa
+    git
     helix
     iw
     macchanger

--- a/configuration.nix
+++ b/configuration.nix
@@ -225,7 +225,7 @@
     shell = pkgs.fish;
   };
 
-  # Enable experimental features for searching
+  # Enable nix-command for search and flakes
   nix = {
    package = pkgs.nixFlakes;
    extraOptions = pkgs.lib.optionalString (config.nix.package == pkgs.nixFlakes)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1692763155,
+        "narHash": "sha256-qMrGKZ8c/q/mHO3ZdrcBPwiVVXPLLgXjY98Ejqb5kAA=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "6a20e40acaebf067da682661aa67da8b36812606",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1692794066,
+        "narHash": "sha256-H0aG8r16dj0x/Wz6wQhQxc9V7AsObOiHPaKxQgH6Y08=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fc944919f743bb22379dddf18dcb72db6cff84aa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -7,30 +7,26 @@
         ]
       },
       "locked": {
-        "lastModified": 1692763155,
-        "narHash": "sha256-qMrGKZ8c/q/mHO3ZdrcBPwiVVXPLLgXjY98Ejqb5kAA=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "6a20e40acaebf067da682661aa67da8b36812606",
-        "type": "github"
+        "narHash": "sha256-/pSusGhmIdSdAaywQRFA5dVbfdIzlWQTecM+E46+cJ0=",
+        "type": "tarball",
+        "url": "https://github.com/nix-community/home-manager/archive/release-23.05.tar.gz"
       },
       "original": {
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://github.com/nix-community/home-manager/archive/release-23.05.tar.gz"
       }
     },
     "nixpkgs": {
       "locked": {
         "lastModified": 1692794066,
         "narHash": "sha256-H0aG8r16dj0x/Wz6wQhQxc9V7AsObOiHPaKxQgH6Y08=",
-        "owner": "NixOS",
+        "owner": "nixos",
         "repo": "nixpkgs",
         "rev": "fc944919f743bb22379dddf18dcb72db6cff84aa",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
+        "owner": "nixos",
         "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+  outputs = { nixpkgs, home-manager, ... }: {
+    nixosConfigurations.cafe = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        ./configuration.nix
+        home-manager.nixosModules.home-manager {
+          home-manager.useGlobalPkgs = true;
+          home-manager.useUserPackages = true;
+          home-manager.users.h = import ./home.nix;
+        }
+      ];
+    };
+    
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,23 +1,47 @@
 {
+  description = "NixOS configuration";
+
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
-    home-manager = {
-      url = "github:nix-community/home-manager";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
+    home-manager.url = "https://github.com/nix-community/home-manager/archive/release-23.05.tar.gz";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
   };
-  outputs = { nixpkgs, home-manager, ... }: {
-    nixosConfigurations.cafe = nixpkgs.lib.nixosSystem {
-      system = "x86_64-linux";
-      modules = [
-        ./configuration.nix
-        home-manager.nixosModules.home-manager {
-          home-manager.useGlobalPkgs = true;
-          home-manager.useUserPackages = true;
-          home-manager.users.h = import ./home.nix;
-        }
-      ];
+
+  outputs = inputs@{ nixpkgs, home-manager, ... }: {
+    nixosConfigurations = {
+      cafe = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          ./configuration.nix
+          home-manager.nixosModules.home-manager
+          {
+            home-manager.useGlobalPkgs = true;
+            home-manager.useUserPackages = true;
+            home-manager.users.h = import ./home.nix;
+
+            # Optionally, use home-manager.extraSpecialArgs to pass
+            # arguments to home.nix
+          }
+        ];
+      };
     };
-    
+
+    devShells = builtins.mapAttrs (system: pkgs:
+    let
+      rebuild = pkgs.writeShellApplication {
+        name = "cafe-rebuild";
+        runtimeInputs = [ pkgs.nixos-rebuild ];
+        text = ''
+          exec nixos-rebuild \
+            --flake '.#cafe' \
+            "$@"
+        '';
+      };
+      in {
+        default = pkgs.mkShell {
+          nativeBuildInputs = [ rebuild ];
+      };
+    }) nixpkgs.legacyPackages;
   };
+  
 }

--- a/home.nix
+++ b/home.nix
@@ -1,11 +1,8 @@
 { config, pkgs, ... }:
 
 {
-
-  home-manager.users.h = {
-    home.stateVersion = "23.05";
-
-    home.file = {
+  home = {
+    file = {
       ".config/helix/config.toml".source = ./sources/helix/config.toml;
       ".config/fish" = {
         source = ./sources/fish;
@@ -19,5 +16,6 @@
       ".local/share/applications/fish.desktop".source = ./sources/fish.desktop;
       ".local/share/blackbox/schemes/lain.json".source = ./sources/blackbox/lain.json;
     };
+    stateVersion = "23.05";
   };
 }

--- a/home.nix
+++ b/home.nix
@@ -1,11 +1,6 @@
 { config, pkgs, ... }:
 
 {
-  imports  = [
-    # nix-channel --add https://github.com/nix-community/home-manager/archive/release-23.05.tar.gz home-manager
-    # nix-channel --update
-    <home-manager/nixos>
-  ];
 
   home-manager.users.h = {
     home.stateVersion = "23.05";


### PR DESCRIPTION
### Changes
- Home manager module is now separated from main config and is only used in conjunction with `flake.nix`.
- Created convenience command `cafe-rebuild` in flake dev shell to rebuild using the current flake.